### PR TITLE
improve progress popover layout

### DIFF
--- a/src/app/components/progress-popover/progress-popover.component.scss
+++ b/src/app/components/progress-popover/progress-popover.component.scss
@@ -15,8 +15,9 @@ dl {
 
   dt {
     width: 80px;
-    display: inline-block;
     font-weight: var(--font-weight-medium);
+    float: left;
+    clear: left;
   }
 
   dd {


### PR DESCRIPTION
<img width="240" alt="Screenshot 2019-06-18 at 7 01 01 AM" src="https://user-images.githubusercontent.com/791368/59639714-fc911800-9196-11e9-83a0-fc12fe25cdec.png">

`dt` and `dd` are now top-aligned.