### PR TITLE
[AV2-44] Re-order and align elements in progress and nav bar

### DIFF
--- a/src/app/components/progress-popover/progress-popover.component.html
+++ b/src/app/components/progress-popover/progress-popover.component.html
@@ -6,18 +6,18 @@
       </ion-col>
     </ion-row>
     <ion-row class="status-container">
-      <ion-col size="3">
+      <ion-col size="3" size-sm>
         <ion-label class="title">Status</ion-label>
       </ion-col>
-      <ion-col class="container-body">
+      <ion-col size="7" class="container-body">
         <ion-label>{{ status }}</ion-label>
       </ion-col>
     </ion-row>
     <ion-row class="submit-container">
-      <ion-col size="3">
+      <ion-col size="3" size-sm>
         <ion-label class="title">Submitted</ion-label>
       </ion-col>
-      <ion-col class="container-body">
+      <ion-col size="7" class="container-body">
         <ng-container *ngIf="progress.submitted">
           <ion-label [ngClass]="{'warning': progress.overdue}"
             *ngIf="progress.status !== 'not started' || progress.status !== 'in progress' else submittedTmp">
@@ -33,10 +33,10 @@
       </ion-col>
     </ion-row>
     <ion-row class="due-container">
-      <ion-col size="3">
+      <ion-col size="3" size-sm>
         <ion-label class="title">Due</ion-label>
       </ion-col>
-      <ion-col class="container-body">
+      <ion-col size="7" class="container-body">
         <ng-container *ngIf="progress.due_date">
           <ion-label [ngClass]="{'danger': progress.overdue}"
             *ngIf="progress.status === 'not started' || progress.status === 'in progress' else duedateTmp">

--- a/src/app/components/progress-popover/progress-popover.component.scss
+++ b/src/app/components/progress-popover/progress-popover.component.scss
@@ -1,6 +1,6 @@
 .progress-popover {
   padding: 12px 16px 20px;
-  min-width: 224px;
+  min-width: 300px;
   min-height: 164px;
   max-height: fit-content;
 

--- a/src/app/components/progress-table/progress-table.component.html
+++ b/src/app/components/progress-table/progress-table.component.html
@@ -27,7 +27,7 @@
     <ng-container *ngIf="type === 'student'">
       <ngx-datatable-column
         name="Student"
-        [width]="240"
+        [width]="220"
         [sortable]="false"
         [canAutoResize]="false"
         [draggable]="false"
@@ -45,14 +45,14 @@
       <ngx-datatable-column
         name="Project"
         prop="team"
-        [width]="90"
+        [width]="120"
         [sortable]="false"
         [canAutoResize]="false"
         [draggable]="false"
         [resizeable]="false">
         <ng-template let-value="value" ngx-datatable-cell-template>
             <div class="project">
-              <p>{{value}}</p>
+              <p title="{{showTooltip(value)}}">{{ value }}</p>
             </div>
           </ng-template>
       </ngx-datatable-column>
@@ -62,14 +62,14 @@
       <ngx-datatable-column
         name="Project"
         prop="name"
-        [width]="90"
+        [width]="120"
         [sortable]="false"
         [canAutoResize]="false"
         [draggable]="false"
         [resizeable]="false">
         <ng-template let-value="value" ngx-datatable-cell-template>
             <div class="project">
-              <p>{{value}}</p>
+              <p title="{{showTooltip(value)}}">{{ value }}</p>
             </div>
           </ng-template>
       </ngx-datatable-column>

--- a/src/app/components/progress-table/progress-table.component.scss
+++ b/src/app/components/progress-table/progress-table.component.scss
@@ -89,5 +89,9 @@
   p {
     margin: 0;
     line-height: 36px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 200px;
   }
 }

--- a/src/app/components/progress-table/progress-table.component.ts
+++ b/src/app/components/progress-table/progress-table.component.ts
@@ -264,4 +264,8 @@ export class ProgressTableComponent implements OnInit {
     });
   }
 
+  showTooltip(projectName: string) {
+    return projectName.length > 13 ? projectName : '';
+  }
+
 }

--- a/src/theme/pfas/_data-tables.scss
+++ b/src/theme/pfas/_data-tables.scss
@@ -16,19 +16,19 @@
 }
 
 .ngx-datatable.material .datatable-header .datatable-header-cell {
-  padding: .75rem 1.5rem .75rem 0;
+  padding: .75rem .5rem .75rem 0;
   color: var(--ion-text-color);
   font-size: 14px;
   line-height: 24px;
 }
 
 .ngx-datatable.material .datatable-body .datatable-body-row .datatable-body-cell {
-  padding: .5rem 1.5rem .5rem 0;
+  padding: .5rem .5rem .5rem 0;
   color: var(--ion-text-color);
   line-height: 20px;
 }
 .ngx-datatable.material .datatable-body .datatable-body-row .datatable-body-group-cell {
-  padding: .5rem 1.5rem .5rem 0;
+  padding: .5rem .5rem .5rem 0;
   color: var(--ion-text-color);
   line-height: 20px;
 }


### PR DESCRIPTION
in this PR,
fixed issue in popover - in popover not align correctly with short assessment names.
fixed project name cut off issue - add `...` if project name long than cell space and added tooltip to show full project name. tooltip only shows if project name too long.

Jira - https://intersective.atlassian.net/browse/CUT-44